### PR TITLE
Prevent shared notes from being added more than once

### DIFF
--- a/src/Share.vue
+++ b/src/Share.vue
@@ -30,12 +30,26 @@ export default {
     // get db and store the new item
     const uuid = localStorage.getItem('uuid')
     const db = new PouchDB(uuid)
-    await db.put({
-      _id: uid(),
-      type: 'Share',
-      value: this.id,
-      sort: -1
+
+    // store the new shared item in the db, if it is not there yet
+    const sharedId = this.id
+    db.query(function (doc, emit) {
+      if (doc.value === sharedId) {
+        emit(doc)
+      }
+    }).then(function (result) {
+      if (!result.rows) {
+        db.put({
+          _id: uid(),
+          type: 'Share',
+          value: sharedId,
+          sort: -1
+        })
+      }
+    }).catch(function (err) {
+      console.log(err)
     })
+
     return this.$router.replace({ name: 'list' })
   }
 }


### PR DESCRIPTION
### **Current behavior:**

The shared note link will add a new element to the db, every time you visit the link. This can result in:
 1. having multiple instances of the same note from another account
 2. having multiple instances of your own shared note (if you happen to open the link yourself)

### New behavior

Add the shared note to db only if there is not other not with that shared id.