### PR TITLE
Disable editing when loading items

### DIFF
--- a/src/components/GridItem.vue
+++ b/src/components/GridItem.vue
@@ -7,7 +7,7 @@
       <template v-slot:top-toolbar-right>
         <q-icon v-if="$q.platform.is.mobile && draggable" class="handle text-grey-5" name="drag_indicator" size="xs" dense />
         <div v-else>
-          <q-btn round flat size="sm" :icon="value.pinned ? 'push_pin' : 'o_push_pin'" class="pin-button" @click="pinItem" v-if="active">
+          <q-btn round flat size="sm" :icon="value.pinned ? 'push_pin' : 'o_push_pin'" class="pin-button" @click="pinItem" v-if="canEdit && active">
             <q-tooltip v-if="value.pinned">Unpin</q-tooltip>
             <q-tooltip v-else>Pin</q-tooltip>
           </q-btn>
@@ -15,20 +15,21 @@
       </template>
       <template v-slot:bottom-toolbar-left>
         <div class="active-buttons">
-          <q-btn dense flat round icon="archive" @click="archiveItem" v-if="active && !isArchiveItem">
+          <q-btn dense flat round icon="archive" @click="archiveItem" v-if="canEdit && active && !isArchiveItem">
             <q-tooltip>Archive</q-tooltip>
           </q-btn>
-          <folder-selector :folders="folders" :current-folder="value.folder" @move="folderItem" @selecting="selectingFolder = true" @not-selecting="selectingFolder = false" v-if="active" />
-          <q-btn dense flat round icon="delete" @click="deleteItem" v-if="active">
+          <folder-selector :folders="folders" :current-folder="value.folder" @move="folderItem" @selecting="selectingFolder = true" @not-selecting="selectingFolder = false" v-if="canEdit && active" />
+          <q-btn dense flat round icon="delete" @click="deleteItem" v-if="canEdit && active">
             <q-tooltip>Delete</q-tooltip>
           </q-btn>
         </div>
       </template>
       <template v-slot:bottom-toolbar-right>
         <div class="active-buttons">
-          <q-btn v-if="!value.new && active" flat round dense icon="share" @click.prevent="shareItem">
+          <q-btn v-if="canEdit && !value.new && active" flat round dense icon="share" @click.prevent="shareItem">
             <q-tooltip>Share</q-tooltip>
           </q-btn>
+          <q-spinner v-if="loading" color="primary" size="2em" />
         </div>
       </template>
     </component>
@@ -50,6 +51,9 @@ export default {
     },
     folders: {
       default: []
+    },
+    loading: {
+      default: false
     }
   },
   data () {
@@ -82,8 +86,10 @@ export default {
       this.$emit('change', id)
     },
     onClick () {
-      this.$emit('click')
-      this.selectingFolder = false
+      if (this.canEdit) {
+        this.$emit('click')
+        this.selectingFolder = false
+      }
     },
     mouseOver () {
       this.active = true
@@ -101,6 +107,9 @@ export default {
     },
     isArchiveItem () {
       return this.value?.folder === String.fromCharCode(0) + 'Archive'
+    },
+    canEdit () {
+      return !this.loading
     }
   }
 }

--- a/src/pages/List.vue
+++ b/src/pages/List.vue
@@ -12,13 +12,13 @@
 
     <div class="search-results items-grid scroll-y column" v-if="searchItems">
       <div v-for="(item, idx) in searchItems" :key="idx" class="display-item">
-        <grid-item :value="item" :folders="folders" @delete="deleteItem" @change="onEdited" @click="editItem(item)" @share="onShare" @moveToFolder="setItemFolder" />
+        <grid-item :loading="loading" :value="item" :folders="folders" @delete="deleteItem" @change="onEdited" @click="editItem(item)" @share="onShare" @moveToFolder="setItemFolder" />
       </div>
     </div>
 
     <draggable v-if="!searchItems && displayPinned.length" v-model="displayPinned" :handle="this.$q.platform.is.mobile ? '.handle' : false" :class="'scroll-y column items-' + displayMode" ref="pinned" v-bind:style="{ height: viewportHeight['pinned'] }">
       <div v-for="(item, idx) in displayPinned" :key="idx" class="display-item">
-        <grid-item :value="item" :draggable="true" :folders="folders" @delete="deleteItem" @change="onEdited" @click="editItem(item)" @share="onShare" @pin="onPin" @moveToFolder="setItemFolder" />
+        <grid-item :loading="loading" :value="item" :draggable="true" :folders="folders" @delete="deleteItem" @change="onEdited" @click="editItem(item)" @share="onShare" @pin="onPin" @moveToFolder="setItemFolder" />
       </div>
     </draggable>
 
@@ -33,7 +33,7 @@
 
     <draggable v-if="!searchItems" v-model="displayItems" :handle="this.$q.platform.is.mobile ? '.handle' : false" :class="'scroll-y column items-' + displayMode" ref="unpinned" v-bind:style="{ height: viewportHeight['unpinned'] }">
       <div v-for="(item, idx) in displayItems" :key="idx" class="display-item">
-        <grid-item :value="item" :draggable="true" :folders="folders" @delete="deleteItem" @change="onEdited" @click="editItem(item)" @share="onShare" @pin="onPin" @moveToFolder="setItemFolder" />
+        <grid-item :loading="loading" :value="item" :draggable="true" :folders="folders" @delete="deleteItem" @change="onEdited" @click="editItem(item)" @share="onShare" @pin="onPin" @moveToFolder="setItemFolder" />
       </div>
     </draggable>
 
@@ -41,7 +41,7 @@
       <q-tooltip :value="showFtueTooltip" :delay="2000" anchor="center left" self="center right">
         Tap the button to get started. <q-icon name="east" />
       </q-tooltip>
-      <q-fab icon="edit" color="primary" :text-color="$q.dark.isActive ? 'dark' : ''" direction="up" vertical-actions-align="right" @show="showFtueTooltip = false">
+      <q-fab v-if="!loading" icon="edit" color="primary" :text-color="$q.dark.isActive ? 'dark' : ''" direction="up" vertical-actions-align="right" @show="showFtueTooltip = false">
         <q-fab-action color="primary" :text-color="$q.dark.isActive ? 'dark' : ''" label-position="left" icon="sticky_note_2" label="Note" @click="createNew('Note')" />
         <q-fab-action color="primary" :text-color="$q.dark.isActive ? 'dark' : ''" label-position="left" icon="fact_check" label="Checklist" @click="createNew('Checklist')" />
       </q-fab>
@@ -109,11 +109,13 @@ export default {
         pinned: '0px'
       },
       showFtueTooltip: false,
-      showIosTooltip: false
+      showIosTooltip: false,
+      loading: false
     }
   },
   methods: {
     async loadItems () {
+      this.loading = true
       const folder = this.folder
 
       await this.db.createIndex({
@@ -166,6 +168,8 @@ export default {
       this.loadFolders()
 
       this.resizeViewports()
+
+      this.loading = false
     },
     async loadFolders () {
       const allFolders = await this.db.find({


### PR DESCRIPTION
### **Current behavior:**

_In a scenario where the app is used from different devices._

* When the homepage is loaded the notes display the content stored locally, then the db is queried to fetch updates that were applied from other devices.
* Getting the data from the database can easily take more than a couple of seconds
* When loading data, the user is able to edit, delete, move notes

That means the notes can be edited while their content is being fetched, which might result in inconsistencies (or with old data being saved in place of newer one).

### **New behavior:**

While data is being loaded from the db, 
1. Disable:
   - delete, move to folder, archive buttons
   - pin button
   - share button
   - click on the note (to trigger the edit view)
3. Display a spinner at the bottom right corner of every note