### PR TITLE
Use Node 16 to avoid SSL error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # develop stage
-FROM node:alpine as build-stage
+FROM node:16-alpine as build-stage
 
 ARG PROD
 ARG DB_URL


### PR DESCRIPTION
A simple change to use Node 16 explicitly. 

Fixes Issue #61 