### PR TITLE
Fix checkbox uncheck bug

### DIFF
--- a/src/components/Checklist/EditChecklist.vue
+++ b/src/components/Checklist/EditChecklist.vue
@@ -168,7 +168,8 @@ export default {
       }
     },
     onUnChecked (item) {
-      item.selected = false
+      item.value.selected = false
+      item.value.checked = false
       this.onChange()
     },
     onChange () {


### PR DESCRIPTION
### Details
* This PR fixes the bug by setting both selected and checked to false when unchecking an item from the edit modal

### To reproduce the bug:
 1. Check an item on a checklist from the view (not the edit modal)
 2. Uncheck the item from the edit modal
 3. The item remains checked
![immagine](https://github.com/user-attachments/assets/5450dd05-0db7-4a5b-860b-ba475a71b14d)
